### PR TITLE
Getting the right class instead of spring proxy class

### DIFF
--- a/src/main/java/com/wizzdi/flexicore/boot/rest/service/RESTPluginHandlerService.java
+++ b/src/main/java/com/wizzdi/flexicore/boot/rest/service/RESTPluginHandlerService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.*;
+import org.springframework.util.ClassUtils;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -40,7 +41,7 @@ public class RESTPluginHandlerService  {
 			for (Object plugin : springControllers.values()) {
 				try {
 					Object proxy;
-					Class<?> restClass = plugin.getClass();
+					Class<?> restClass = ClassUtils.getUserClass(plugin);
 					if (!aspects.isEmpty()) {
 						logger.debug("rest class "+restClass+" will be proxied with aspects");
 						AspectJProxyFactory factory = new AspectJProxyFactory(plugin);


### PR DESCRIPTION
I had a problem with Rest Services that extends from an abstract class and annotated with `@PreAuthorize`. In this situation I get an error message
 
`Name for argument of type [int] not specified, and parameter name information not found in class file either.`
 
The mapping couldn’t find, because the classes are proxied from Spring Boot. `ClassUtils.getUserClass()` resolved the right class.
